### PR TITLE
Add email property to process

### DIFF
--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -18,6 +18,7 @@
   :class (s-prefix "proces:Proces")
   :properties `((:title :string ,(s-prefix "dct:title"))
                 (:description :string ,(s-prefix "dct:description"))
+                (:email :string ,(s-prefix "schema:email"))
                 (:created :datetime ,(s-prefix "dct:created"))
                 (:modified :datetime ,(s-prefix "dct:modified"))
                 (:status :url ,(s-prefix "adms:status")))

--- a/config/resources/repository.lisp
+++ b/config/resources/repository.lisp
@@ -21,3 +21,4 @@
 (add-prefix "proces" "https://data.vlaanderen.be/ns/proces#")
 (add-prefix "cogs" "http://vocab.deri.ie/cogs#")
 (add-prefix "task" "http://redpencil.data.gift/vocabularies/tasks/")
+(add-prefix "schema" "https://schema.org/")


### PR DESCRIPTION
OPH-323

Corresponding PR frontend: https://github.com/lblod/frontend-openproceshuis/pull/46

Next to a Bestuur having an email address, a process can also have specific email address.