### PR TITLE
Use mu-search for process steps

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -3,8 +3,8 @@
 
 (in-package :delta-messenger)
 
+(add-delta-logger)
 (add-delta-messenger "http://deltanotifier/")
-(setf *log-delta-messenger-message-bus-processing* nil)
 
 ;;;;;;;;;;;;;;;;;
 ;;; Configuration

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -13,4 +13,18 @@ export default [
       ignoreFromSelf: true,
     },
   },
+  {
+    match: {
+      // listen to all changes
+    },
+    callback: {
+      url: "http://search/update",
+      method: "POST",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 10000,
+      ignoreFromSelf: true,
+    },
+  },
 ];

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -23,7 +23,7 @@ export default [
     },
     options: {
       resourceFormat: "v0.0.1",
-      gracePeriod: 10000,
+      gracePeriod: 1000,
       ignoreFromSelf: true,
     },
   },

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -91,8 +91,6 @@ defmodule Dispatcher do
   ###############################################################
 
   match "/search/*path", %{  accept: [:json], layer: :api} do
-    # All data is public --> force mu-search to always use same index
-    conn = Plug.Conn.put_req_header(conn, "mu-auth-allowed-groups", "[{\"variables\":[],\"name\":\"public\"},{\"variables\":[],\"name\":\"clean\"}]")
     Proxy.forward conn, path, "http://search/"
   end
 

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -91,6 +91,8 @@ defmodule Dispatcher do
   ###############################################################
 
   match "/search/*path", %{  accept: [:json], layer: :api} do
+    # All data is public --> force mu-search to always use same index
+    conn = Plug.Conn.put_req_header(conn, "mu-auth-allowed-groups", "[{\"variables\":[],\"name\":\"public\"},{\"variables\":[],\"name\":\"clean\"}]")
     Proxy.forward conn, path, "http://search/"
   end
 

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -118,7 +118,7 @@
   :on-path "exclusive-gateways")
 
 (define-resource inclusiveGateway (bpmnElement)
-  :class (s-prefix "bbo:ExclusiveGateway")
+  :class (s-prefix "bbo:InclusiveGateway")
   :properties `((:defaultElement :string ,(s-prefix "bbo:has_defaultElement"))
                 (:outgoing :string ,(s-prefix "bbo:has_outgoing"))
                 (:incoming :string ,(s-prefix "bbo:has_incoming")))

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -9,11 +9,23 @@
   ],
   "default_settings": {
     "analysis": {
+      "char_filter": {
+        "remove_special_characters": {
+          "type": "pattern_replace",
+          "pattern": "[:/.-]",
+          "replacement": ""
+        }
+      },
       "normalizer": {
         "custom_sort_normalizer": {
           "type": "custom",
           "char_filter": [],
           "filter": ["lowercase", "trim", "asciifolding"]
+        },
+        "custom_uri_normalizer": {
+          "type": "custom",
+          "char_filter": ["remove_special_characters"],
+          "filter": ["lowercase", "asciifolding"]
         }
       }
     }
@@ -123,7 +135,8 @@
             }
           },
           "bpmn-process.bpmn-file.status": {
-            "type": "keyword"
+            "type": "keyword",
+            "normalizer": "custom_uri_normalizer"
           },
           "bpmn-process.bpmn-file.processes.title": {
             "type": "text",
@@ -135,7 +148,8 @@
             }
           },
           "bpmn-process.bpmn-file.processes.status": {
-            "type": "keyword"
+            "type": "keyword",
+            "normalizer": "custom_uri_normalizer"
           }
         }
       }

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -1,6 +1,7 @@
 {
   "automatic_index_updates": true,
   "persist_indexes": true,
+  "update_wait_interval_minutes": 0.2,
   "number_of_threads": 4,
   "eager_indexing_groups": [
     [{ "name": "public", "variables": [] }],

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -73,6 +73,55 @@
             }
           }
         }
+      },
+      "mappings": {
+        "properties": {
+          "name": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "type.label": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "type.key": {
+            "type": "keyword"
+          },
+          "bpmn-process.bpmn-file.name": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "bpmn-process.bpmn-file.status": {
+            "type": "keyword"
+          },
+          "bpmn-process.bpmn-file.processes.title": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "bpmn-process.bpmn-file.processes.status": {
+            "type": "keyword"
+          }
+        }
       }
     }
   ]

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -3,6 +3,10 @@
   "automatic_index_updates": true,
   "persist_indexes": true,
   "number_of_threads": 4,
+  "eager_indexing_groups": [
+    [{ "name": "public", "variables": [] }],
+    [{ "name": "clean", "variables": [] }]
+  ],
   "default_settings": {
     "analysis": {
       "normalizer": {

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -2,6 +2,17 @@
   "automatic_index_updates": true,
   "persist_indexes": true,
   "number_of_threads": 4,
+  "default_settings": {
+    "analysis": {
+      "normalizer": {
+        "custom_sort_normalizer": {
+          "type": "custom",
+          "char_filter": [],
+          "filter": ["lowercase", "trim", "asciifolding"]
+        }
+      }
+    }
+  },
   "types": [
     {
       "type": "bpmn-element",

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -2,180 +2,75 @@
   "automatic_index_updates": true,
   "persist_indexes": true,
   "number_of_threads": 4,
-  "eager_indexing_groups": [
-    [
-      {
-        "variables": [],
-        "name": "antwerp-editor"
-      },
-      {
-        "variables": [],
-        "name": "clean"
-      },
-      {
-        "variables": [],
-        "name": "public"
-      }
-    ],
-    [
-      {
-        "variables": [],
-        "name": "leuven-editor"
-      },
-      {
-        "variables": [],
-        "name": "clean"
-      },
-      {
-        "variables": [],
-        "name": "public"
-      }
-    ],
-    [
-      {
-        "variables": [],
-        "name": "clean"
-      },
-      {
-        "variables": [],
-        "name": "public"
-      }
-    ]
-  ],
-  "default_settings": {
-    "analysis": {
-      "normalizer": {
-        "custom_sort_normalizer": {
-          "type": "custom",
-          "char_filter": [],
-          "filter": [
-            "lowercase",
-            "trim",
-            "asciifolding"
-          ]
-        }
-      }
-    }
-  },
   "types": [
     {
       "type": "bpmn-element",
       "on_path": "bpmn-elements",
       "rdf_type": [
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#Activity",
+        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#Task",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#BoundaryEvent",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#BusinessRuleTask",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#CallableElement",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#CatchEvent",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#EndEvent",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#Error",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#ErrorEventDefinition",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#Event",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#EventDefinition",
+        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#Error",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#ExclusiveGateway",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#FlowElement",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#FlowElementsContainer",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#FlowNode",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#Gateway",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#InclusiveGateway",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#IntermediateThrowEvent",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#ManualTask",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#MessageEventDefinition",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#ParallelGateway",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#Process",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#Property",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#ReceiveTask",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#RootElement",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#ScriptTask",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#SendTask",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#SequenceFlow",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#ServiceTask",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#StartEvent",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#SubProcess",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#Task",
-        "https://www.irit.fr/recherches/MELODI/ontologies/BBO#ThrowEvent",
         "https://www.irit.fr/recherches/MELODI/ontologies/BBO#UserTask",
+        "https://www.teamingai-project.eg/BBOExtension#Association",
         "https://www.teamingai-project.eg/BBOExtension#Collaboration",
+        "https://www.teamingai-project.eg/BBOExtension#DataInputAssociation",
         "https://www.teamingai-project.eg/BBOExtension#DataObject",
         "https://www.teamingai-project.eg/BBOExtension#DataObjectReference",
+        "https://www.teamingai-project.eg/BBOExtension#DataOutputAssociation",
+        "https://www.teamingai-project.eg/BBOExtension#DataStoreReference",
         "https://www.teamingai-project.eg/BBOExtension#Lane",
         "https://www.teamingai-project.eg/BBOExtension#LaneSet",
-        "https://www.teamingai-project.eg/BBOExtension#Participant"
+        "https://www.teamingai-project.eg/BBOExtension#MessageFlow",
+        "https://www.teamingai-project.eg/BBOExtension#Participant",
+        "https://www.teamingai-project.eg/BBOExtension#TextAnnotation"
       ],
       "properties": {
-        "name": [
-          "https://www.irit.fr/recherches/MELODI/ontologies/BBO#name"
-        ],
-        "classification": [
-          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-        ],
-        "processes": {
+        "name": "https://www.irit.fr/recherches/MELODI/ontologies/BBO#name",
+        "type": {
+          "via": "http://purl.org/dc/terms/type",
+          "rdf_type": "http://www.w3.org/2004/02/skos/core#Concept",
+          "properties": {
+            "label": "http://www.w3.org/2004/02/skos/core#prefLabel",
+            "key": "http://www.w3.org/2004/02/skos/core#hiddenLabel"
+          }
+        },
+        "bpmn-process": {
           "via": "https://www.teamingai-project.eu/belongsToProcess",
           "rdf_type": "https://www.irit.fr/recherches/MELODI/ontologies/BBO#Process",
           "properties": {
-            "name": [
-              "http://www.w3.org/ns/prov#wasDerivedFrom",
-              "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName"
-            ],
-            "created": [
-              "http://www.w3.org/ns/prov#wasDerivedFrom",
-              "http://purl.org/dc/terms/created"
-            ],
-            "modified": [
-              "http://www.w3.org/ns/prov#wasDerivedFrom",
-              "http://purl.org/dc/terms/modified"
-            ],
-            "fileId": [
-              "http://www.w3.org/ns/prov#wasDerivedFrom",
-              "^http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource",
-              "http://mu.semte.ch/vocabularies/core/uuid"
-            ]
-          }
-        }
-      },
-      "mappings": {
-        "properties": {
-          "name": {
-            "type": "text",
-            "fields": {
-              "field": {
-                "type": "keyword",
-                "normalizer": "custom_sort_normalizer"
+            "bpmn-file": {
+              "via": "http://www.w3.org/ns/prov#wasDerivedFrom",
+              "rdf_type": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
+              "properties": {
+                "name": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName",
+                "status": "http://www.w3.org/ns/adms#status",
+                "processes": {
+                  "via": "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#isPartOf",
+                  "rdf_type": "https://data.vlaanderen.be/ns/proces#Proces",
+                  "properties": {
+                    "title": "http://purl.org/dc/terms/title",
+                    "status": "http://www.w3.org/ns/adms#status"
+                  }
+                }
               }
             }
-          },
-          "fileId": {
-            "type": "text",
-            "fields": {
-              "field": {
-                "type": "keyword",
-                "normalizer": "custom_sort_normalizer"
-              }
-            }
-          },
-          "classification": {
-            "type": "text",
-            "fields": {
-              "field": {
-                "type": "keyword",
-                "normalizer": "custom_sort_normalizer"
-              }
-            }
-          },
-          "processes.name": {
-            "type": "text",
-            "fields": {
-              "field": {
-                "type": "keyword",
-                "normalizer": "custom_sort_normalizer"
-              }
-            }
-          },
-          "processes.created": {
-            "type": "date"
-          },
-          "processes.modified": {
-            "type": "date"
           }
         }
       }

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -1,5 +1,4 @@
 {
-  "enable_raw_dsl_endpoint": true,
   "automatic_index_updates": true,
   "persist_indexes": true,
   "number_of_threads": 4,

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -1,4 +1,5 @@
 {
+  "enable_raw_dsl_endpoint": true,
   "automatic_index_updates": true,
   "persist_indexes": true,
   "number_of_threads": 4,

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -1,7 +1,7 @@
 {
   "automatic_index_updates": true,
   "persist_indexes": true,
-  "update_wait_interval_minutes": 0.2,
+  "update_wait_interval_minutes": 0.1,
   "number_of_threads": 4,
   "eager_indexing_groups": [
     [{ "name": "public", "variables": [] }],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
   # MU SEARCH
   ################################################################################
   search:
-    image: semtech/mu-search:0.9.3
+    image: semtech/mu-search:0.10.0-beta.5
     links:
       - database:database
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,7 @@ services:
   # MU SEARCH
   ################################################################################
   search:
-    image: semtech/mu-search:0.9.1
+    image: semtech/mu-search:0.9.3
     links:
       - database:database
     restart: always
@@ -150,7 +150,7 @@ services:
     labels:
       - "logging=true"
     logging: *default-logging
-    image: semtech/mu-search-elastic-backend:1.0.1
+    image: semtech/mu-search-elastic-backend:1.1.0
     volumes:
       - ./data/elasticsearch/:/usr/share/elasticsearch/data
     environment:

--- a/scripts/reset-elastic.sh
+++ b/scripts/reset-elastic.sh
@@ -3,7 +3,7 @@ echo "warning this will run queries on the triplestore and delete containers, yo
 sleep 3
 docker compose rm -fs elasticsearch search
 sudo rm -rf data/elasticsearch/
-docker compose exec -T triplestore isql-v <<EOF
+docker compose exec -T virtuoso isql-v <<EOF
 SPARQL DELETE WHERE {   GRAPH <http://mu.semte.ch/authorization> {     ?s ?p ?o.   } };
 exec('checkpoint');
 exit;

--- a/scripts/reset-elastic.sh
+++ b/scripts/reset-elastic.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 echo "warning this will run queries on the triplestore and delete containers, you have 3 seconds to press ctrl+c"
 sleep 3
-docker-compose rm -fs elasticsearch search
+docker compose rm -fs elasticsearch search
 sudo rm -rf data/elasticsearch/
-docker-compose exec -T triplestore isql-v <<EOF
+docker compose exec -T triplestore isql-v <<EOF
 SPARQL DELETE WHERE {   GRAPH <http://mu.semte.ch/authorization> {     ?s ?p ?o.   } };
 exec('checkpoint');
 exit;
 EOF
-docker-compose up -d --remove-orphan
+docker compose up -d --remove-orphan


### PR DESCRIPTION
OPH-335
OPH-358

Corresponding PR frontend: https://github.com/lblod/frontend-openproceshuis/pull/51

For better performance, all data regarding the displaying of process steps, is indexed by mu-search.

The highlighted parts show which attributes are indexed:
![schema](https://github.com/user-attachments/assets/83ebbb23-c459-4864-b27d-e4556adf6edc)