### PR TITLE
Make impersonation work with ACM/IDM

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -3,6 +3,7 @@
 
 (in-package :delta-messenger)
 
+(setf *delta-handlers* nil)
 (add-delta-logger)
 (add-delta-messenger "http://deltanotifier/")
 
@@ -10,11 +11,11 @@
 ;;; Configuration
 
 (in-package :client)
-(setf *log-sparql-query-roundtrip* nil)
+(setf *log-sparql-query-roundtrip* t)
 (setf *backend* "http://virtuoso:8890/sparql")
 
 (in-package :server)
-(setf *log-incoming-requests-p* nil)
+(setf *log-incoming-requests-p* t)
 
 ;;;;;;;;;;;;;;;;
 ;;; Prefix types

--- a/config/migrations/2024/20241205125830-add-abb-group.graph
+++ b/config/migrations/2024/20241205125830-add-abb-group.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2024/20241205125830-add-abb-group.ttl
+++ b/config/migrations/2024/20241205125830-add-abb-group.ttl
@@ -1,0 +1,11 @@
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+
+<http://data.lblod.info/id/bestuurseenheden/3b29ce9c-47d4-4245-8dca-1e42ed03bc04>
+  mu:uuid "3b29ce9c-47d4-4245-8dca-1e42ed03bc04" ;
+  rdf:type besluit:Bestuurseenheid ;
+  skos:prefLabel "Agentschap Binnenlands Bestuur" ;
+  dct:identifier "OVO001835" .


### PR DESCRIPTION
OPH-406

Migrations was added to make sure the application knows about the "Agentschap Binnenlands Bestuur" group, used by ACM/IDM for users with admin role.