### PR TITLE
Display organization types

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -22,6 +22,10 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://cache/bpmn-element-types/"
   end
 
+  match "/administrative-unit-classification-codes", %{ accept: [:json], layer: :api } do
+    Proxy.forward conn, [], "http://cache/administrative-unit-classification-codes/"
+  end
+
   post "/bpmn",  %{ accept: [:any], layer: :api } do
     Proxy.forward conn, [], "http://bpmn/"
   end

--- a/config/resources/auth.json
+++ b/config/resources/auth.json
@@ -2,8 +2,7 @@
   "version": "0.1",
   "prefixes": {
     "foaf": "http://xmlns.com/foaf/0.1/",
-    "organisatie": "https://data.vlaanderen.be/ns/organisatie#",
-    "code": "http://lblod.data.gift/vocabularies/organisatie/",
+    "organisatie": "http://lblod.data.gift/vocabularies/organisatie/",
     "adres": "https://data.vlaanderen.be/ns/adres#",
     "schema_http": "http://schema.org/",
     "ere": "http://data.lblod.info/vocabularies/erediensten/",
@@ -110,7 +109,7 @@
       "new-resource-base": "http://data.lblod.info/id/vestigingen/"
     },
     "site-types": {
-      "class": "code:TypeVestiging",
+      "class": "organisatie:TypeVestiging",
       "attributes": {
         "label": {
           "type": "string",
@@ -145,6 +144,16 @@
       },
       "relationships": {},
       "new-resource-base": "http://data.lblod.info/id/contact-punten/"
+    },
+    "administrative-unit-classification-codes": {
+      "class": "organisatie:BestuurseenheidClassificatieCode",
+      "attributes": {
+        "label": {
+          "type": "string",
+          "predicate": "skos:prefLabel"
+        }
+      },
+      "new-resource-base": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/"
     }
   }
 }


### PR DESCRIPTION
OPH-405

PR frontend: https://github.com/lblod/frontend-openproceshuis/pull/59

Display the type (classification) of process' organization. Also allow sorting and filtering on the type.