### PR TITLE
Link government types to processes

### DIFF
--- a/config/resources/auth.json
+++ b/config/resources/auth.json
@@ -82,6 +82,12 @@
           "predicate": "org:hasPrimarySite",
           "target": "sites",
           "cardinality": "one"
+        },
+        "processes": {
+          "predicate": "dct:publisher",
+          "target": "process",
+          "cardinality": "many",
+          "inverse": "true"
         }
       },
       "new-resource-base": "http://data.lblod.info/id/bestuurseenheden/"

--- a/config/resources/auth.json
+++ b/config/resources/auth.json
@@ -153,6 +153,14 @@
           "predicate": "skos:prefLabel"
         }
       },
+      "relationships": {
+        "groups": {
+          "predicate": "org:classification",
+          "target": "group",
+          "cardinality": "many",
+          "inverse": "true"
+        }
+      },
       "new-resource-base": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/"
     }
   }


### PR DESCRIPTION
OPH-449

Corresponding PR frontend: https://github.com/lblod/frontend-openproceshuis/pull/62

Add inverse relationships to allow moving from administrative-unit-classification-code, over group(s), to process(es).

This enables the frontend to list all government types for which processes exist.