### PR TITLE
Differentiate between IPDC instances and concepts

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -173,7 +173,8 @@
   ;; process-type
   ("proces:Proces" -> _)
   ("nfo:FileDataObject" -> _)
-  ("ipdc:InstancePublicService" -> _))
+  ("ipdc:InstancePublicService" -> _)
+  ("ipdc:ConceptualPublicService" -> _))
 
 (define-graph organizations ("http://mu.semte.ch/graphs/organizations/")
   ;; bpmn-element-type
@@ -219,7 +220,8 @@
   ;; process-type
   ("proces:Proces" -> _)
   ("nfo:FileDataObject" -> _)
-  ("ipdc:InstancePublicService" -> _))
+  ("ipdc:InstancePublicService" -> _)
+  ("ipdc:ConceptualPublicService" -> _))
 
 (define-graph public ("http://mu.semte.ch/graphs/public")
   ;; bpmn-element-type
@@ -266,6 +268,7 @@
   ("proces:Proces" -> _)
   ("nfo:FileDataObject" -> _)
   ("ipdc:InstancePublicService" -> _)
+  ("ipdc:ConceptualPublicService" -> _)
   ;; public-type
   ("org:Role" -> _)
   ("besluit:Bestuurseenheid" -> _)

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -30,8 +30,20 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://bpmn/"
   end
 
+  ###############################################################
+  # ipdc
+  ###############################################################
+
   match "/ipdc-instances", %{ accept: [:json], layer: :api } do
     Proxy.forward conn, [], "http://cache/ipdc-instances/"
+  end
+
+  match "/ipdc-concepts", %{ accept: [:json], layer: :api } do
+    Proxy.forward conn, [], "http://cache/ipdc-concepts/"
+  end
+
+  get "/ipdc-products", %{ accept: [:json], layer: :api } do
+    Proxy.forward conn, [], "http://cache/ipdc-products/"
   end
 
   ###############################################################

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -30,8 +30,8 @@
   :has-many `((file :via ,(s-prefix "nie:isPartOf")
                     :inverse t
                     :as "files")
-              (ipdcInstance :via ,(s-prefix "prov:derivation")
-                            :as "ipdc-instances"))
+              (ipdcProduct :via ,(s-prefix "prov:derivation")
+                            :as "ipdc-products"))
   :resource-base (s-url "http://data.lblod.info/processes/")
   :on-path "processes")
 

--- a/config/resources/ipdc.lisp
+++ b/config/resources/ipdc.lisp
@@ -1,8 +1,16 @@
 (in-package :mu-cl-resources)
 
-(define-resource ipdcInstance ()
-  :class (s-prefix "ipdc:InstancePublicService")
+(define-resource ipdcProduct ()
   :properties `((:name :language-string-set ,(s-prefix "dct:title"))
                 (:product-number :string ,(s-prefix "schema:productID")))
+  :on-path "ipdc-products")
+
+(define-resource ipdcInstance (ipdcProduct)
+  :class (s-prefix "ipdc:InstancePublicService")
   :resource-base (s-url "http://data.lblod.info/ipdc-instances/")
   :on-path "ipdc-instances")
+
+(define-resource ipdcConcept (ipdcProduct)
+  :class (s-prefix "ipdc:ConceptualPublicService")
+  :resource-base (s-url "http://data.lblod.info/ipdc-concepts/")
+  :on-path "ipdc-concepts")


### PR DESCRIPTION
PR frontend: https://github.com/lblod/frontend-openproceshuis/pull/64

Whereas before only IPDC instances could be stored in the tripelstore, now IPDC concepts can also be stored.