### PR TITLE
Convert Visio to PDF

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -30,8 +30,8 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://bpmn/"
   end
 
-  post "/visio",  %{ accept: [:any], layer: :api } do
-    Proxy.forward conn, [], "http://visio/"
+  get "/visio/*path",  %{ accept: [:any], layer: :api } do
+    Proxy.forward conn, path, "http://visio/"
   end
 
   ###############################################################

--- a/config/resources/file.lisp
+++ b/config/resources/file.lisp
@@ -11,14 +11,9 @@
                 (:status :url ,(s-prefix "adms:status")))
   :has-one `((file :via ,(s-prefix "nie:dataSource")
                    :inverse t
-                   :as "download")
-             (file :via ,(s-prefix "prov:wasDerivedFrom")
-                   :as "vsdx-file"))
+                   :as "download"))
   :has-many `((process :via ,(s-prefix "nie:isPartOf")
-                       :as "processes")
-              (file :via ,(s-prefix "prov:wasDerivedFrom")
-                    :inverse t
-                    :as "bpmn-files"))
+                       :as "processes"))
   :resource-base (s-url "http://data.lblod.info/files/")
   :features `(include-uri)
   :on-path "files")


### PR DESCRIPTION
OPH-419

Corresponding PRs:
- Visio service: https://github.com/lblod/openproceshuis-visio-service/pull/2
- Frontend: https://github.com/lblod/frontend-openproceshuis/pull/68

The Visio service functionality is expanded as it can now also convert a given Visio file to PDF.