### PR TITLE
Fix statistics not updating for public users

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -111,6 +111,10 @@
        :for-allowed-group "public")
 
 (grant (read write)
+       :to-graph statistics
+       :for-allowed-group "public")
+
+(grant (read write)
        :to-graph organizations
        :for-allowed-group "org")
 
@@ -174,8 +178,7 @@
   ("proces:Proces" -> _)
   ("nfo:FileDataObject" -> _)
   ("ipdc:InstancePublicService" -> _)
-  ("ipdc:ConceptualPublicService" -> _)
-  ("ext:ProcessStatistic" -> _))
+  ("ipdc:ConceptualPublicService" -> _))
 
 (define-graph organizations ("http://mu.semte.ch/graphs/organizations/")
   ;; bpmn-element-type
@@ -222,8 +225,7 @@
   ("proces:Proces" -> _)
   ("nfo:FileDataObject" -> _)
   ("ipdc:InstancePublicService" -> _)
-  ("ipdc:ConceptualPublicService" -> _)
-  ("ext:ProcessStatistic" -> _))
+  ("ipdc:ConceptualPublicService" -> _))
 
 (define-graph public ("http://mu.semte.ch/graphs/public")
   ;; bpmn-element-type
@@ -271,7 +273,6 @@
   ("nfo:FileDataObject" -> _)
   ("ipdc:InstancePublicService" -> _)
   ("ipdc:ConceptualPublicService" -> _)
-  ("ext:ProcessStatistic" -> _)
   ;; public-type
   ("org:Role" -> _)
   ("besluit:Bestuurseenheid" -> _)
@@ -297,3 +298,7 @@
 (define-graph reports ("http://mu.semte.ch/graphs/reports")
   ("reporting:Report" -> _)
   ("nfo:FileDataObject" -> _))
+
+(define-graph statistics ("http://mu.semte.ch/graphs/statistics")
+  ("ext:ProcessStatistic" -> _)
+  ("proces:Proces" -> "ext:hasStatistics"))

--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -175,7 +175,7 @@
   ("bboext:LaneSet" -> _)
   ("bboext:Participant" -> _)
   ;; process-type
-  ("proces:Proces" -> _)
+  ("proces:Proces" x> "ext:hasStatistics")
   ("nfo:FileDataObject" -> _)
   ("ipdc:InstancePublicService" -> _)
   ("ipdc:ConceptualPublicService" -> _))
@@ -222,7 +222,7 @@
   ("bboext:LaneSet" -> _)
   ("bboext:Participant" -> _)
   ;; process-type
-  ("proces:Proces" -> _)
+  ("proces:Proces" x> "ext:hasStatistics")
   ("nfo:FileDataObject" -> _)
   ("ipdc:InstancePublicService" -> _)
   ("ipdc:ConceptualPublicService" -> _))
@@ -269,7 +269,7 @@
   ("bboext:LaneSet" -> _)
   ("bboext:Participant" -> _)
   ;; process-type
-  ("proces:Proces" -> _)
+  ("proces:Proces" x> "ext:hasStatistics")
   ("nfo:FileDataObject" -> _)
   ("ipdc:InstancePublicService" -> _)
   ("ipdc:ConceptualPublicService" -> _)

--- a/config/migrations/2025/20250221103154-move-statistics.sparql
+++ b/config/migrations/2025/20250221103154-move-statistics.sparql
@@ -1,0 +1,26 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX proces: <https://data.vlaanderen.be/ns/proces#>
+
+DELETE {
+  GRAPH ?g {
+    ?process ext:hasStatistics ?stat .
+    ?stat a ext:ProcessStatistic ;
+          ?p ?o .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/statistics> {
+    ?process ext:hasStatistics ?stat .
+    ?stat a ext:ProcessStatistic ;
+          ?p ?o .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?process ext:hasStatistics ?stat .
+    ?stat a ext:ProcessStatistic ;
+          ?p ?o .
+  }
+  
+  FILTER(?g != <http://mu.semte.ch/graphs/statistics>)
+}


### PR DESCRIPTION
When not logged, process detail pages wouldn't load properly because non-authorized users couldn't send write requests regarding statistics.

This PR fixes this by storing all statistics-relevant information in a statistics graph (and nowhere else) and giving everyone read/write access to it.