### PR TITLE
don't use custom boolean types

### DIFF
--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -9,6 +9,8 @@
 (defparameter *cache-count-queries* t)
 (defparameter *supply-cache-headers-p* t)
 
+(defparameter *use-custom-boolean-type-p* nil)
+
 (read-domain-file "auth.json")
 (read-domain-file "job.lisp")
 (read-domain-file "file.lisp")


### PR DESCRIPTION
Little tweak to the `domain.lisp`
This fixes a bug where boolean values didn't get overwritten. 