### PR TITLE
upgrade virtuoso

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     logging: *default-logging
     labels:
       - "logging=true"
-    image: tenforce/virtuoso:1.3.2-virtuoso7.2.5.1
+    image: redpencil/virtuoso:1.2.1
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"


### PR DESCRIPTION
This PR will upgrade our Virtuoso to v1.2.1

**Note:** According to the Virtuoso docs it is advised to dump your data to quads. This needs to be done on the server itself. 
After that you should delete the old db files and move the dumps to the `toLoad` folder. After that is done you can update the `docker-compose.yml` with the new version and restart the Virtuoso container. Are we doing it this way or just bumping the docker compose?

[Upgrade instructions](https://github.com/redpencilio/docker-virtuoso?tab=readme-ov-file#upgrading) 
