### PR TITLE
Fix incorrect or missing district identifiers

### DIFF
--- a/config/migrations/2025/20250715151513-update-districts.sparql
+++ b/config/migrations/2025/20250715151513-update-districts.sparql
@@ -1,0 +1,27 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+DELETE {
+  ?district dcterms:identifier ?oldId .
+}
+INSERT {
+  ?district
+    dcterms:identifier ?ovo ;
+    dcterms:identifier ?kbo .
+}
+WHERE {
+  VALUES (?district ?ovo ?kbo) {
+    ( <http://data.lblod.info/id/bestuurseenheden/5be3ff820769b385a32e499d17bbf1f15feeacb65381d5384841732dd4a1209b> "OVO003105" "2165924084" ) # Antwerpen
+    ( <http://data.lblod.info/id/bestuurseenheden/fb56bc40ce36390d2f12fc2057c89d4b6bc5b3217eabd41995b6401318ff648a> "OVO003106" "2165911218" ) # Berchem
+    ( <http://data.lblod.info/id/bestuurseenheden/859f08dcfbc8f68bac0879e7baf6463b260b6f4c16b734d0d1986f5f3af0407b> "OVO003107" "2165940120" ) # Berendrecht-Zandvliet-Lillo
+    ( <http://data.lblod.info/id/bestuurseenheden/e7a75861661ee14ebe2bca0c79bda8b23f2f943d00a9693d2bff401a8f8dea65> "OVO003108" "2165997726" ) # Borgerhout
+    ( <http://data.lblod.info/id/bestuurseenheden/4b44e6f1-113b-4692-b149-44a889b215f2>                             "OVO002030" "2165162239" ) # Borsbeek
+    ( <http://data.lblod.info/id/bestuurseenheden/43e3009526dac139a0abdcf75c1ddc5fa3fe9217391d6f64f7b7a30a99a4cda6> "OVO003109" "2165926559" ) # Deurne
+    ( <http://data.lblod.info/id/bestuurseenheden/33a1886b07b64ebe3a0e6c5ed8086f030ef1109492cb254832a716dd7e1b8d7b> "OVO003110" "2166001684" ) # Ekeren
+    ( <http://data.lblod.info/id/bestuurseenheden/a2ee394059cce91526392e73e4de974d90caffb92f70cde23b9e9e1a965526fa> "OVO003111" "2165926262" ) # Hoboken
+    ( <http://data.lblod.info/id/bestuurseenheden/f1ad80291fbdc1f0b9b25d729ecc608a8e28fdddab01a1b8e135c841c75586e2> "OVO003112" "2165996340" ) # Merksem
+    ( <http://data.lblod.info/id/bestuurseenheden/73e8904d83f7324e39abc0adf639b0e48bc52533c4c243b6419cac8fb70784cf> "OVO003113" "2165906862" ) # Wilrijk
+  }
+  OPTIONAL {
+    ?district dcterms:identifier ?oldId .
+  }
+}

--- a/config/migrations/2025/20250715151513-update-districts.sparql
+++ b/config/migrations/2025/20250715151513-update-districts.sparql
@@ -1,12 +1,16 @@
 PREFIX dcterms: <http://purl.org/dc/terms/>
 
 DELETE {
-  ?district dcterms:identifier ?oldId .
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?district dcterms:identifier ?oldId .
+  }
 }
 INSERT {
-  ?district
-    dcterms:identifier ?ovo ;
-    dcterms:identifier ?kbo .
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?district
+      dcterms:identifier ?ovo ;
+      dcterms:identifier ?kbo .
+  }
 }
 WHERE {
   VALUES (?district ?ovo ?kbo) {


### PR DESCRIPTION
OPH-639

Logging in through ACM/IDM using a district didn't work as most them had missing or even incorrect identifiers. From the lblod rocketchat channel, it became clear the OP consumer had issues with districts and the go-to solution seemed to be fixing things through migrations.

The following districts had missing KBO numbers:
- Antwerpen
- Berendrecht-Zandvliet-Lillo
- Deurne
- Ekeren
- Hoboken
- Merksem

The following district had a missing OVO number:
- Borsbeek

The following district had an incorrect OVO and KBO number:
- Berchem