### PR TITLE
Add anonymization service

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -26,12 +26,20 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://cache/administrative-unit-classification-codes/"
   end
 
+  ###############################################################
+  # API
+  ###############################################################
+
   post "/bpmn",  %{ accept: [:any], layer: :api } do
     Proxy.forward conn, [], "http://bpmn/"
   end
 
   get "/visio/*path",  %{ accept: [:any], layer: :api } do
     Proxy.forward conn, path, "http://visio/"
+  end
+
+  post "/anonymization/bpmn", %{ accept: [:any], layer: :api } do
+    Proxy.forward conn, [], "http://anonymization/bpmn"
   end
 
   ###############################################################

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,3 +27,4 @@ services:
     image: lblod/openproceshuis-bpmn-service:latest
   visio:
     image: lblod/openproceshuis-visio-service:latest
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,3 +228,7 @@ services:
     labels:
       - "logging=true"
     logging: *default-logging
+  anonymization:
+    image: lblod/pii-identification-anonymization-service:feature-detect-pii-in-bpmn
+    ports:
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -229,6 +229,6 @@ services:
       - "logging=true"
     logging: *default-logging
   anonymization:
-    image: lblod/pii-identification-anonymization-service:feature-detect-pii-in-bpmn
+    image: lblod/pii-identification-anonymization-service
     ports:
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -230,5 +230,4 @@ services:
     logging: *default-logging
   anonymization:
     image: lblod/pii-identification-anonymization-service
-    ports:
-      - "8080:8080"
+    restart: always


### PR DESCRIPTION
This is the backend PR for lblod/frontend-openproceshuis#112

- Added anonymization service in docker compose file
- Added dispatcher rule for bpmn endpoint

**Note:** I added the latest image but for some reason the bpmn endpoint didn't work yet. 
Maybe it was something i overlooked or the build including the bpmn endpoint failed. 
If using `latest` doesn't work, use `lblod/pii-identification-anonymization-service:feature-detect-pii-in-bpmn`