### PR TITLE
map to conceptualProcess instead of linkedConcept

### DIFF
--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -41,7 +41,7 @@
                     :as "publisher")
              (processStatistic :via ,(s-prefix "ext:hasStatistics")
                                :as "process-statistics")
-             (linkedConcept :via ,(s-prefix "dct:source")
+             (conceptualProcess :via ,(s-prefix "dct:source")
                                :as "linked-concept"))
   :has-many `((file :via ,(s-prefix "nie:isPartOf")
                     :inverse t


### PR DESCRIPTION
During developing a feature in the frontend that relied on the conceputalProcess resource, i saw the link to conceptualProcess was wrongly set as linkedConcept. This should fix it.