### PR TITLE
Dispatch all anonymization requests to anonymization service

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -40,6 +40,7 @@ defmodule Dispatcher do
 
   post "/anonymization/*path", %{ accept: [:any], layer: :api } do
     Proxy.forward conn, path, "http://anonymization/"
+  end
 
   ###############################################################
   # inventory


### PR DESCRIPTION
OPH-667

Dispatch all requests made to the `/anonymization` endpoint to the PII identification and anonymization service.