### PR TITLE
OPH-1015 | show one process uri per row in report

### DIFF
--- a/config/reports/process-counts-report.js
+++ b/config/reports/process-counts-report.js
@@ -30,10 +30,10 @@ export default {
           WHERE {
             ?group a besluit:Bestuurseenheid ;
                    skos:prefLabel ?groupName .
-
-            ?process a dpv:Process ;
-                     dct:publisher ?group .
-
+            graph <http://mu.semte.ch/graphs/shared> {
+              ?process a dpv:Process .
+              ?process dct:publisher ?group .
+            }
             OPTIONAL { ?process adms:status ?status }
 
             BIND(IF(?status = <http://lblod.data.gift/concepts/concept-status/gearchiveerd>, STR(?process), UNDEF) AS ?archivedProcess)
@@ -48,6 +48,7 @@ export default {
                  (COUNT(DISTINCT ?unarchivedProcess) AS ?unarchivedProcesses)
                  (COUNT(DISTINCT ?archivedProcess) AS ?archivedProcesses)
                  (COUNT(DISTINCT ?process) AS ?totalProcesses)
+          FROM <http://mu.semte.ch/graphs/shared>
           WHERE {
             ?process a dpv:Process .
 

--- a/config/reports/processes-report.js
+++ b/config/reports/processes-report.js
@@ -21,17 +21,29 @@ export default {
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX icr: <http://lblod.data.gift/vocabularies/informationclassification/>
 
-      SELECT DISTINCT ?groupName ?title ?created ?modified ?status ?processViews ?bpmnDownloads ?pdfDownloads ?svgDownloads ?pngDownloads (GROUP_CONCAT(DISTINCT ?adminUnitLabel; SEPARATOR="; ") AS ?adminUnitLabels)
+      SELECT  ?process 
+              ?organizationLabel 
+              ?title 
+              ?created 
+              (MAX(?modified) AS ?lastModified) 
+              (SAMPLE(?status) AS ?status) 
+              (MAX(?processViews) AS ?maxViews) 
+              (MAX(?bpmnDownloads) AS ?maxBpmn) 
+              (MAX(?pdfDownloads) AS ?maxPdf) 
+              (MAX(?svgDownloads) AS ?maxSvg) 
+              (MAX(?pngDownloads) AS ?maxPng) 
+              (GROUP_CONCAT(DISTINCT ?adminUnitLabel; SEPARATOR="; ") AS ?adminUnitLabels)
       WHERE {
         ?group a besluit:Bestuurseenheid ;
-               skos:prefLabel ?groupName .
+        skos:prefLabel ?organizationLabel .
 
-        ?process a dpv:Process ;
-                 dct:publisher ?group ;
-                 dct:title ?title ;
-                 dct:created ?created ;
-                 dct:modified ?modified .
-                 
+        graph <http://mu.semte.ch/graphs/shared> {
+          ?process a dpv:Process .
+          ?process dct:publisher ?group .
+          ?process dct:title ?title .
+          ?process dct:created ?created .
+          ?process dct:modified ?modified .
+        } 
         OPTIONAL { ?process adms:status ?status }
         OPTIONAL { 
           ?process ext:hasStatistics ?stats .
@@ -41,23 +53,22 @@ export default {
           OPTIONAL { ?stats ext:svgDownloads ?svgDownloads }
           OPTIONAL { ?stats ext:pdfDownloads ?pdfDownloads }
         }
-          OPTIONAL {
-                     ?process icr:isRelevantForAdministrativeUnit ?adminUnit .
+        OPTIONAL {
+          ?process icr:isRelevantForAdministrativeUnit ?adminUnit .
           OPTIONAL { ?adminUnit skos:prefLabel ?adminUnitLabel }
         }
-
-}
-      GROUP BY ?groupName ?title ?created ?modified ?status ?processViews ?bpmnDownloads ?pdfDownloads ?svgDownloads ?pngDownloads
-      ORDER BY LCASE(?groupName) LCASE(?title) ?created
-       
+      }
+      GROUP BY ?process ?organizationLabel ?title ?created ?lastModified
+      ORDER BY LCASE(?organizationLabel) LCASE(?title) ?created  
     `;
     const queryResponse = await batchedQuery(queryString);
 
     const data = queryResponse.results.bindings.map((process) => ({
-      Bestuur: process.groupName.value,
+      Uri: process.process.value,
       Proces: process.title.value,
+      Bestuur: process.organizationLabel.value,
       "Aangemaakt op": formatDate(process.created.value),
-      "Aangepast op": formatDate(process.modified.value),
+      "Aangepast op": formatDate(process.lastModified.value),
       Gearchiveerd:
         process.status?.value ===
         "http://lblod.data.gift/concepts/concept-status/gearchiveerd"
@@ -84,13 +95,13 @@ export default {
     await generateReportFromData(
       data,
       [
-        "Bestuur",
+        "Uri",
         "Proces",
+        "Bestuur",
         "Aangemaakt op",
         "Aangepast op",
         "Gearchiveerd",
         "Relevant voor type bestuur",
-        "Aantal weergaven",
         "Totaal aantal downloads",
         "Aantal downloads (bpmn)",
         "Aantal downloads (pdf)",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,9 +23,6 @@ services:
   process:
     image: lblod/openproceshuis-process-service:latest
     restart: "no"
-  report-generation:
-    environment:
-      NODE_ENV: "development"
   sparql-endpoint-proxy:
     restart: "no"
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,6 +23,9 @@ services:
   process:
     image: lblod/openproceshuis-process-service:latest
     restart: "no"
+  report-generation:
+    environment:
+      NODE_ENV: "development"
   sparql-endpoint-proxy:
     restart: "no"
     environment:


### PR DESCRIPTION
## 🗒️ Description

The all processen report is outputing multi lines for the same process uri. This should not be happening. This is happening because of multiple modified date and so mutliple edits on a process.

Also checked with the PM and we would like to also show the process uri in the report.

Also looked ad the report count query and this is not outputting the correct number.

## 🦮 How to test

- First create both reports without this PR as a reference
- Do an edit on a process
- Create a report, every uri in there should be unique
- The count report should output the correct processes => just filte ron bestuur en see results in all processen table

This could occur but as you see these have different uris
```
| http://data.lblod.info/processes/679398D9C6E009ADB3495B8F | AGB Nieuwpoort Vrije Tijd                                              | Finale BPMN Proces_ik-word-Belg                                     | 2025-01-24T13:42:51.984Z | 2025-01-24T13:42:51.984Z |                                                             |      133 |       0 |      0 |      0 |      0 |                                                       |                                |
| http://data.lblod.info/processes/67CABCD3435091678276296E | AGB Nieuwpoort Vrije Tijd                                              | Finale BPMN Proces_ik-word-Belg                                     | 2025-03-07T09:30:59.378Z | 2025-03-07T13:06:45.031Z |                                                             |       88 |       7 |      3 |      0 |      0 |                                                       |                                |
```
<img width="1353" height="284" alt="image" src="https://github.com/user-attachments/assets/72c17e98-a16b-48bf-bd7e-4290626baba1" />


## 🔗 Links to other PR's

- https://app.gitbook.com/o/-MP9Yduzf5xu7wIebqPG/s/XKRwfgAcZ0dhzZWkI6YJ/research-and-information/reporting/custom-reports/configured-reports
