### PR TITLE
feat: LoketLB-admin admin role is also allowed for the ipdc-proxy to …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -269,7 +269,7 @@ services:
     environment:
       API_URL: "https://api.ipdc.tni-vlaanderen.be"
       API_KEY: "secret"
-      REQUIRED_ROLES: "OpenProcesHuis-Procesbeheerder,LoketLB-OpenProcesHuisGebruiker,LoketLB-OpenProcesHuisAfnemer" # TODO: drop support for LoketLB-OpenProcesHuisGebruiker and LoketLB-OpenProcesHuisAfnemer when ready
+      REQUIRED_ROLES: "OpenProcesHuis-Procesbeheerder,LoketLB-OpenProcesHuisGebruiker,LoketLB-OpenProcesHuisAfnemer,LoketLB-admin" # TODO: drop support for LoketLB-OpenProcesHuisGebruiker and LoketLB-OpenProcesHuisAfnemer when ready
     restart: always
     labels:
       - "logging=true"


### PR DESCRIPTION
## 🗒️ Description

We are not allowing admins to fetch the ipdc-proxy service, we do not know why as they should. Add the role to allowed roles

## 🦮 How to test

-  Added the role on prod service as well, go check out the prod frontend and log in as an ABB (aka admin role) This loggs below are from prod server
```
ipdc-proxy-1  | Starting server on 0.0.0.0:80 in production mode
ipdc-proxy-1  | PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
ipdc-proxy-1  |                   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
ipdc-proxy-1  |                   SELECT DISTINCT ?session_group WHERE {
ipdc-proxy-1  |                     <http://mu.semte.ch/sessions/232da3e8-3703-11f1-9135-0242ac120005> ext:sessionGroup/mu:uuid ?session_group;
ipdc-proxy-1  |                                  ext:sessionRole ?role.
ipdc-proxy-1  |                      FILTER(?role in ("OpenProcesHuis-Procesbeheerder","LoketLB-OpenProcesHuisGebruiker","LoketLB-OpenProcesHuisAfnemer","LoketLB-admin"))
ipdc-proxy-1  |                     }
```
- network call gets passed now
<img width="1914" height="664" alt="image" src="https://github.com/user-attachments/assets/d07bc536-43ca-4868-8597-10c77f7ea4e1" />


