### PR TITLE
OPH-1016 | let the frontend go through the plausible-proxy

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -203,6 +203,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://ipdc-proxy/"
   end
 
+  match "/plausible/*path", %{ accept: [:any], layer: :api } do
+    Proxy.forward conn, path, "http://plausible-proxy/"
+  end
+
   ###############################################################
   # frontend
   ###############################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,7 @@ services:
       EMBER_OAUTH_API_SCOPE: "openid rrn profile vo abb_openproceshuis"
       EMBER_OAUTH_SWITCH_URL: "https://openproceshuis.lblod.info/switch-login"
       EMBER_ANALYTICS_APP_DOMAIN: "openproceshuis.lblod.info" # Prod: openproceshuis.vlaanderen.be
-      EMBER_ANALYTICS_API_HOST: "https://plausible.lblod.info"
-
+      EMBER_ANALYTICS_API_HOST: "/plausible"
     volumes:
       - ./config/frontend/add-x-frame-options-header.conf:/config/add-x-frame-options.conf
     labels:
@@ -325,6 +324,17 @@ services:
       API_URL: "https://api.ipdc.tni-vlaanderen.be"
       API_KEY: "secret"
       REQUIRED_ROLES: "OpenProcesHuis-Procesbeheerder,LoketLB-OpenProcesHuisGebruiker,LoketLB-OpenProcesHuisAfnemer,LoketLB-admin" # TODO: drop support for LoketLB-OpenProcesHuisGebruiker and LoketLB-OpenProcesHuisAfnemer when ready
+    restart: always
+    labels:
+      - "logging=true"
+    logging: *default-logging
+  plausible-proxy:
+    image: lblod/api-proxy-service:1.0.2
+    links:
+      - virtuoso:database
+    environment:
+      API_URL: "https://plausible.lblod.info"
+      API_KEY: ""
     restart: always
     labels:
       - "logging=true"


### PR DESCRIPTION
## 🗒️ Description

When a i use an adblocker the plasuible events do not get through, we use a proxy here to get around it.

## 🦮 How to test

1. Its active on DEV
2. Enable  tracklocalhost in the frontend code https://github.com/redpencilio/ember-plausible?tab=readme-ov-file#api


## 🔗 Links to other PR's

- https://github.com/lblod/frontend-openproceshuis/pull/207

## Attachments

<img width="1462" height="815" alt="image" src="https://github.com/user-attachments/assets/fc2a09d2-1ebe-4c73-8ec4-ac8dcd298e89" />

