### PR TITLE
fix: add all roles to the ipdc-proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -323,7 +323,7 @@ services:
     environment:
       API_URL: "https://api.ipdc.tni-vlaanderen.be"
       API_KEY: "secret"
-      REQUIRED_ROLES: "OpenProcesHuis-Procesbeheerder,LoketLB-OpenProcesHuisGebruiker,LoketLB-OpenProcesHuisAfnemer,LoketLB-admin" # TODO: drop support for LoketLB-OpenProcesHuisGebruiker and LoketLB-OpenProcesHuisAfnemer when ready
+      REQUIRED_ROLES: "OpenProcesHuis-Procesbeheerder,LoketLB-OpenProcesHuisGebruiker,LoketLB-OpenProcesHuisAfnemer,LoketLB-admin,Lezer,OpenProcesHuis-Lezer,Medewerker-fixed" # TODO: drop support for LoketLB-OpenProcesHuisGebruiker and LoketLB-OpenProcesHuisAfnemer when ready
     restart: always
     labels:
       - "logging=true"


### PR DESCRIPTION
## 🗒️ Description

We got a user with Lezer role that gets the notification that ipdc cannot be fetched. This PR resolves this as we limit access base on the roles.

## 🦮 How to test

1. Should not get notified when correct roles
<img width="320" height="228" alt="image" src="https://github.com/user-attachments/assets/c183691e-6b74-4731-8479-1cb2b0f2c0d7" />



