### PR TITLE
OPH-1039 | provide health check for m2m-login service

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -184,6 +184,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://vendor-api/"
   end
 
+  get "/m2m/*path", %{ accept: [:any], layer: :api} do
+    Proxy.forward conn, path, "http://m2m/"
+  end
+
   post "/m2msessions/*path", %{ accept: [:any], layer: :api} do
     Proxy.forward conn, path, "http://m2m/sessions/"
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,7 +221,7 @@ services:
   # Integration services
   ################################################################################  
   m2m:
-    image: lblod/m2m-login-service:0.1.0
+    image: lblod/m2m-login-service:0.1.1
     environment:
       MU_APPLICATION_GRAPH: "http://mu.semte.ch/graphs/public"
       MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/.well-known/oauth-authorization-server/op"


### PR DESCRIPTION
Refs: oph-1039

## 🗒️ Description

We need a health checkpoint for our m2m service so we can setup a metric to be notified when this service is down. This is the start to prevent a vendor not being able to use our services.

## 🦮 How to test

1. http://localhost/m2m/health-check return status 200 with ok
<img width="853" height="206" alt="image" src="https://github.com/user-attachments/assets/be3a3bb0-0c00-4145-8e07-a20c4560594d" />


## 🔗 Links to other PR's

- https://github.com/lblod/m2m-login-service/pull/1 `v0.1.1`
