### PR TITLE
Add audit vlaanderen through migration

### DIFF
--- a/config/migrations/2026/20260423093500-add-audit-vlaanderen.sparql
+++ b/config/migrations/2026/20260423093500-add-audit-vlaanderen.sparql
@@ -1,0 +1,27 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX lblod-org: <http://lblod.data.gift/vocabularies/organisatie/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+
+    # Classification code
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/811c2f0b-7cb3-42af-bfbe-eebc0d25c4b5> 
+      rdf:type lblod-org:BestuurseenheidClassificatieCode, ext:OrganizationClassificationCode ;
+      skos:prefLabel "Audit Vlaanderen" ;
+      mu:uuid "811c2f0b-7cb3-42af-bfbe-eebc0d25c4b5" .
+
+    # Bestuurseenheid
+    <http://data.lblod.info/id/bestuurseenheden/df2c0b8d-8405-49b3-8330-8e918378ea34>
+      a besluit:Bestuurseenheid ;
+      mu:uuid "df2c0b8d-8405-49b3-8330-8e918378ea34" ;
+      skos:prefLabel "Audit Vlaanderen" ;
+      dct:identifier "OVO001832" ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/811c2f0b-7cb3-42af-bfbe-eebc0d25c4b5> .
+  }
+}


### PR DESCRIPTION
## 🗒️ Description

Since Audit Vlaanderen wants to use OPH and their organization data doesn't exist in OP, the migration in this PR adds their data manually.