### PR TITLE
Update Virtuoso image version to 1.2.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     logging: *default-logging
     labels:
       - "logging=true"
-    image: redpencil/virtuoso:1.2.1
+    image: redpencil/virtuoso:1.2.2
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"


### PR DESCRIPTION
## 🗒️ Description

this is a minor bump and should be fully compatible with 1.2.1. It disables some built in functions that could be called from the SPARQL endpoint  that  could potentially be abused.

## 🦮 How to test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## 🔗 Links to other PR's

- /
