### PR TITLE
Bump virtuoso and SPARQL parser

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     logging: *default-logging
     labels:
       - "logging=true"
-    image: semtech/sparql-parser:0.0.14
+    image: semtech/sparql-parser:0.0.15
     volumes:
       - ./config/authorization:/config
       - ./data/authorization:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     logging: *default-logging
     labels:
       - "logging=true"
-    image: redpencil/virtuoso:1.2.2
+    image: redpencil/virtuoso:1.4.0
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"


### PR DESCRIPTION
## 🗒️ Description

- Virtuoso is bumped to v1.4.0.
- SPARQL parser is bumped to v0.0.15.

From UX perspective, this should have no impact. We should therefore test the application to make sure everything works as before.

## 🦮 How to test

1. Make sure you pull all images.

2. Before running, check whether `data/db/virtuoso.trx` is (as good as) empty or non-existent. If it is, you can safely delete it:

```bash
rm ./data/db/virtuoso.trx
```

3. Run the stack.

4. Go through the application (frontend) and try out some things. Best is to make sure as much queries as possible are fired in the background. If all behaves normally, that's good.

## 🔗 Links to other PR's

- /
