### PR TITLE
Drop support for old roles

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -73,7 +73,6 @@
             FILTER(?role IN (\"Medewerker-fixed\", \"OpenProcesHuis-Lezer\"))
           }")
 
-;; TODO: drop support for LoketLB-OpenProcesHuisGebruiker and LoketLB-OpenProcesHuisAfnemer when ready
 (supply-allowed-group "organization-processes-editor"
   :parameters ("graph_extension")
   :query "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -91,13 +90,12 @@
               ?group mu:uuid ?group_id ;
                      dct:identifier ?identifier .
             }
-            FILTER(?role IN (\"OpenProcesHuis-Procesbeheerder\", \"LoketLB-OpenProcesHuisGebruiker\", \"LoketLB-OpenProcesHuisAfnemer\"))
+            FILTER(?role = \"OpenProcesHuis-Procesbeheerder\")
             BIND(IF(?identifier IN (\"OVO001835\", \"OVO002949\"),
                     \"agentschap-binnenlands-bestuur-digitaal-vlaanderen\",
                     ?group_id) AS ?graph_extension)
           }")
 
-;; TODO: drop support for LoketLB-OpenProcesHuisGebruiker and LoketLB-OpenProcesHuisAfnemer when ready
 (supply-allowed-group "shared-processes-editor"
   :query "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
           PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -109,7 +107,7 @@
               <SESSION_ID> ext:originalSessionGroup / mu:uuid ?session_group;
                            ext:originalSessionRole ?role.
             }
-            FILTER(?role IN (\"OpenProcesHuis-Procesbeheerder\", \"LoketLB-OpenProcesHuisGebruiker\", \"LoketLB-OpenProcesHuisAfnemer\"))
+            FILTER(?role = \"OpenProcesHuis-Procesbeheerder\")
           }")
 
 (supply-allowed-group "admin"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -323,7 +323,7 @@ services:
     environment:
       API_URL: "https://api.ipdc.tni-vlaanderen.be"
       API_KEY: "secret"
-      REQUIRED_ROLES: "OpenProcesHuis-Procesbeheerder,LoketLB-OpenProcesHuisGebruiker,LoketLB-OpenProcesHuisAfnemer,LoketLB-admin,Lezer,OpenProcesHuis-Lezer,Medewerker-fixed" # TODO: drop support for LoketLB-OpenProcesHuisGebruiker and LoketLB-OpenProcesHuisAfnemer when ready
+      REQUIRED_ROLES: "OpenProcesHuis-Procesbeheerder,LoketLB-admin,Lezer,OpenProcesHuis-Lezer,Medewerker-fixed"
     restart: always
     labels:
       - "logging=true"


### PR DESCRIPTION
## 🗒️ Description

With this PR, support for the `LoketLB-OpenProcesHuisGebruiker` and `LoketLB-OpenProcesHuisAfnemer` roles has been completely dropped.
While they weren't assigned to mock users anymore, users logging in through ACM/IDM still had the possibility to use any of those two roles.

## 🦮 How to test

This is difficult to truly test in "dev" mode, when moving to QA we'll be able to see whether logging in through ACM/IDM works correctly.

## 🔗 Links to other PR's

- https://github.com/lblod/frontend-openproceshuis/pull/228
