### PR TITLE
oph-1078 | ignore the hasStatistics predicate on the queads so process statist

### DIFF
--- a/config/modified/config.ts
+++ b/config/modified/config.ts
@@ -13,6 +13,9 @@ export const filterModifiedSubjects = "";
 export async function filterDeltas(changeSets: Changeset[]) {
   const modifiedPred = "http://purl.org/dc/terms/modified";
   const subjectsWithModified = new Set();
+  const ignoredPredicates = [
+    "http://mu.semte.ch/vocabularies/ext/hasStatistics", 
+  ];
 
   const trackModifiedSubjects = (quad) => {
     if (quad.predicate.value === modifiedPred) {
@@ -28,7 +31,9 @@ export async function filterDeltas(changeSets: Changeset[]) {
   ];
   const isGoodQuad = (quad) =>
     !subjectsWithModified.has(quad.subject.value) &&
-    !ignoredGraphPrefixes.some((prefix) => quad.graph.value.startsWith(prefix));
+    !ignoredGraphPrefixes.some((prefix) => quad.graph.value.startsWith(prefix)) &&
+    !ignoredPredicates.includes(quad.predicate.value);
+
   return changeSets.map((changeSet) => {
     return {
       inserts: changeSet.inserts.filter(isGoodQuad),


### PR DESCRIPTION
## 🗒️ Description

When going to a process the modified value of the process gets updated. When looking at the logs of the modified service we see that the process and the statistics resource linked to the process is found in the changeset. We can limit this in the modified service.

## 🦮 How to test

1. Go to dev https://dev.openproceshuis.lblod.info/processen/6A0D96747F896D5A0379C2CB
2. Route to the overview page and back
3. The statistics get updated on the process which udpates the process (see the modified service logs)
4. Check out this PR and do the same, now only the statistics resource is found by the modified service and also the frontend modified value will not change everytime you route to the process
5. Check the ticket to see if i didn't miss [anything](https://binnenland.atlassian.net/browse/OPH-1078) 

Log should look like this
```bash
modified-1  | Headers set on SPARQL client: {"requestDefaults":{"headers":{"mu-auth-sudo":"true","mu-session-id":"http://mu.semte.ch/sessions/7d58d0ee-5509-11f1-9cc4-327b79a072e0","mu-call-id":"547c1d10-550a-11f1-8882-7d82a3767be9"}}}
modified-1  | 
modified-1  |     SELECT DISTINCT ?subject ?type WHERE {
modified-1  |       ?subject a ?type .
modified-1  |       VALUES ?subject { <http://data.lblod.info/process-statistics/6A0EEF8B69EBE60F3635920C> }
modified-1  |     }
````