### PR TITLE
OPH-553 | create new migration that moves the exisisting process steps to

### DIFF
--- a/config/migrations/2026/20260529132200-move-process-steps-to-organization-steps-graph.sparql
+++ b/config/migrations/2026/20260529132200-move-process-steps-to-organization-steps-graph.sparql
@@ -65,7 +65,7 @@ where {
     bbo:RootElement
     bbo:ThrowEvent
   }
-  graph ?g {
+  graph <http://mu.semte.ch/graphs/shared> {
     ?element a ?type .
     ?element ?p ?o .
   }
@@ -73,4 +73,71 @@ where {
   ?organization mu:uuid ?organizationId .
   filter(!contains(STR(?g), "http://mu.semte.ch/graphs/process-steps/organizations/"))
   BIND(IRI(CONCAT("http://mu.semte.ch/graphs/process-steps/organizations/", STR(?organizationId))) AS ?targetGraph)
+}
+
+;
+
+prefix ext: <http://mu.semte.ch/vocabularies/ext/>
+prefix bbo: <https://www.irit.fr/recherches/MELODI/ontologies/BBO#>
+prefix bboextension: <https://www.teamingai-project.eg/BBOExtension#>
+prefix mu: <http://mu.semte.ch/vocabularies/core/>
+
+delete {
+  graph <http://mu.semte.ch/graphs/shared> {
+    ?element ?p ?o .
+  }
+}
+where {
+  values ?type {
+    #skos:Concept
+    bbo:Process
+    bbo:Task
+    bbo:BoundaryEvent
+    bbo:BusinessRuleTask
+    bbo:EndEvent
+    bbo:ErrorEventDefinition
+    bbo:Error
+    bbo:ExclusiveGateway
+    bbo:InclusiveGateway
+    bbo:IntermediateThrowEvent
+    bbo:ManualTask
+    bbo:MessageEventDefinition
+    bbo:ParallelGateway
+    bbo:Property
+    bbo:ReceiveTask
+    bbo:ScriptTask
+    bbo:SendTask
+    bbo:SequenceFlow
+    bbo:ServiceTask
+    bbo:StartEvent
+    bbo:SubProcess
+    bbo:UserTask
+    bboextension:Association
+    bboextension:Collaboration
+    bboextension:DataInputAssociation
+    bboextension:DataObject
+    bboextension:DataObjectReference
+    bboextension:DataOutputAssociation
+    bboextension:DataStoreReference
+    bboextension:Lane
+    bboextension:LaneSet
+    bboextension:MessageFlow
+    bboextension:Participant
+    bboextension:TextAnnotation
+    bbo:Activity
+    bbo:CallableElement
+    bbo:CatchEvent
+    bbo:Event
+    bbo:EventDefinition
+    bbo:FlowElement
+    bbo:FlowElementsContainer
+    bbo:FlowNode
+    bbo:Gateway
+    bbo:RootElement
+    bbo:ThrowEvent
+  }
+  graph <http://mu.semte.ch/graphs/shared> {
+    ?element a ?type .
+    ?element ?p ?o .
+  }
 }

--- a/config/migrations/2026/20260529132200-move-process-steps-to-organization-steps-graph.sparql
+++ b/config/migrations/2026/20260529132200-move-process-steps-to-organization-steps-graph.sparql
@@ -1,0 +1,76 @@
+prefix ext: <http://mu.semte.ch/vocabularies/ext/>
+prefix bbo: <https://www.irit.fr/recherches/MELODI/ontologies/BBO#>
+prefix bboextension: <https://www.teamingai-project.eg/BBOExtension#>
+prefix mu: <http://mu.semte.ch/vocabularies/core/>
+
+delete {
+ graph ?g {
+    ?element ?p ?o .
+  }
+}
+insert {
+  graph ?targetGraph {
+    ?element ?p ?o .
+  }
+  graph <http://mu.semte.ch/graphs/public> {
+    ?targetGraph ext:ownedBy ?organization .
+  }
+}
+where {
+  values ?type {
+    #skos:Concept
+    bbo:Process
+    bbo:Task
+    bbo:BoundaryEvent
+    bbo:BusinessRuleTask
+    bbo:EndEvent
+    bbo:ErrorEventDefinition
+    bbo:Error
+    bbo:ExclusiveGateway
+    bbo:InclusiveGateway
+    bbo:IntermediateThrowEvent
+    bbo:ManualTask
+    bbo:MessageEventDefinition
+    bbo:ParallelGateway
+    bbo:Property
+    bbo:ReceiveTask
+    bbo:ScriptTask
+    bbo:SendTask
+    bbo:SequenceFlow
+    bbo:ServiceTask
+    bbo:StartEvent
+    bbo:SubProcess
+    bbo:UserTask
+    bboextension:Association
+    bboextension:Collaboration
+    bboextension:DataInputAssociation
+    bboextension:DataObject
+    bboextension:DataObjectReference
+    bboextension:DataOutputAssociation
+    bboextension:DataStoreReference
+    bboextension:Lane
+    bboextension:LaneSet
+    bboextension:MessageFlow
+    bboextension:Participant
+    bboextension:TextAnnotation
+    bbo:Activity
+    bbo:CallableElement
+    bbo:CatchEvent
+    bbo:Event
+    bbo:EventDefinition
+    bbo:FlowElement
+    bbo:FlowElementsContainer
+    bbo:FlowNode
+    bbo:Gateway
+    bbo:RootElement
+    bbo:ThrowEvent
+  }
+  graph ?g {
+    ?element a ?type .
+    ?element ?p ?o .
+  }
+  ?g ext:ownedBy ?organization .
+  ?organization mu:uuid ?organizationId .
+  filter(!contains(STR(?g), "http://mu.semte.ch/graphs/process-steps/organizations/"))
+  BIND(IRI(CONCAT("http://mu.semte.ch/graphs/process-steps/organizations/", STR(?organizationId))) AS ?targetGraph)
+}


### PR DESCRIPTION
## 🗒️ Description

Now that the process steps are saved from now on on in the organization processs step graph we also need to move the already existing steps to the correct graph as well

## 🦮 How to test

1. Get the query in the migrations but change the insert delete with `  select (count(distinct ?element) as ?elements) ?organizationId`
2. Run the migration and this should be empty
3. Note that all the process step graphs also have the ext:ownedBy setup for possible future logic

## 🔗 Links to other PR's

- /

## Attachments

When looking at the owned by links you should see the ownedBy in the results => normal graph and the process steps
<img width="1896" height="159" alt="image" src="https://github.com/user-attachments/assets/de214fc6-7a6d-4905-934d-b8bcca1db753" />

