### PR TITLE
OPH-1087 | add is blueprint to processes output report

### DIFF
--- a/config/reports/process-counts-report.js
+++ b/config/reports/process-counts-report.js
@@ -19,6 +19,7 @@ export default {
       PREFIX dpv: <https://w3id.org/dpv#>
       PREFIX dct: <http://purl.org/dc/terms/>
       PREFIX adms: <http://www.w3.org/ns/adms#>
+      PREFIX oph: <http://lblod.data.gift/vocabularies/openproceshuis/>      
 
       SELECT *
       WHERE {
@@ -33,6 +34,10 @@ export default {
             graph <http://mu.semte.ch/graphs/shared> {
               ?process a dpv:Process .
               ?process dct:publisher ?group .
+
+              FILTER NOT EXISTS {
+                ?process oph:isVersionedResource "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+              }
             }
             OPTIONAL { ?process adms:status ?status }
 
@@ -51,6 +56,9 @@ export default {
           FROM <http://mu.semte.ch/graphs/shared>
           WHERE {
             ?process a dpv:Process .
+            FILTER NOT EXISTS {
+              ?process oph:isVersionedResource "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+            }
 
             OPTIONAL { ?process adms:status ?status }
 

--- a/config/reports/processes-report.js
+++ b/config/reports/processes-report.js
@@ -23,7 +23,8 @@ export default {
       PREFIX oph: <http://lblod.data.gift/vocabularies/openproceshuis/>      
 
       SELECT  ?process 
-              ?organizationLabel 
+              ?organizationLabel
+              ?isBlueprint 
               ?title 
               ?created 
               (MAX(?modified) AS ?lastModified) 
@@ -49,6 +50,7 @@ export default {
           ?process dct:title ?title .
           ?process dct:created ?created .
           ?process dct:modified ?modified .
+          OPTIONAL { ?process icr:isBlueprint ?isBlueprint }
         } 
         OPTIONAL { ?process adms:status ?status }
         OPTIONAL { 
@@ -65,7 +67,7 @@ export default {
           OPTIONAL { ?adminUnit skos:prefLabel ?adminUnitLabel }
         }
       }
-      GROUP BY ?process ?organizationLabel ?title ?created ?lastModified
+      GROUP BY ?process ?organizationLabel ?isBlueprint ?title ?created ?lastModified
       ORDER BY LCASE(?organizationLabel) LCASE(?title) ?created  
     `;
     const queryResponse = await batchedQuery(queryString);
@@ -81,11 +83,13 @@ export default {
         "http://lblod.data.gift/concepts/concept-status/gearchiveerd"
           ? "Ja"
           : "Nee",
+      Blauwdruk: process.isBlueprint?.value === "1" ? "Ja" : "Nee",
       "Relevant voor type bestuur": process.adminUnitLabels?.value || "",
       "Aantal weergaven": process.maxViews?.value,
       "Totaal aantal downloads": String(
         [
           process.maxBpmn,
+          process.maxVisio,
           process.maxPdf,
           process.maxSvg,
           process.maxPng,
@@ -108,6 +112,7 @@ export default {
         "Bestuur",
         "Aangemaakt op",
         "Aangepast op",
+        "Blauwdruk",
         "Gearchiveerd",
         "Relevant voor type bestuur",
         "Aantal weergaven",

--- a/config/reports/processes-report.js
+++ b/config/reports/processes-report.js
@@ -20,6 +20,7 @@ export default {
       PREFIX adms: <http://www.w3.org/ns/adms#>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX icr: <http://lblod.data.gift/vocabularies/informationclassification/>
+      PREFIX oph: <http://lblod.data.gift/vocabularies/openproceshuis/>      
 
       SELECT  ?process 
               ?organizationLabel 
@@ -40,6 +41,10 @@ export default {
 
         graph <http://mu.semte.ch/graphs/shared> {
           ?process a dpv:Process .
+          FILTER NOT EXISTS {
+            ?process oph:isVersionedResource "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+          }
+
           ?process dct:publisher ?group .
           ?process dct:title ?title .
           ?process dct:created ?created .


### PR DESCRIPTION
## 🗒️ Description

The process overview is not showing if the process is a  blueprint or not. We want this to be included in the ouput csv.

## 🦮 How to test

1. Create a new process make it a blueprint
2. Check the report
3. Remove the blueprint
4. No duplicate processes should be in the output file
5. Download the diagram as every extension and check the output in the csv => total count should now also include the visio downloads

## 🔗 Attachments

<img width="2528" height="79" alt="image" src="https://github.com/user-attachments/assets/710e602f-d200-4d7f-afd7-e8be52fb25ce" />

