### PR TITLE
OPH-1100 | IPDC products not added to the versioned process in the initial migration

### DIFF
--- a/config/migrations/2026/versioning/20260330142100-version-processes.sparql
+++ b/config/migrations/2026/versioning/20260330142100-version-processes.sparql
@@ -39,7 +39,7 @@ WHERE {
                       rdf:type,
                       mu:uuid,
                       dct:isVersionOf,
-                      ext:hasStatistict
+                      ext:hasStatistics
                       )
             ) 
   }

--- a/config/migrations/2026/versioning/20260330142101-fix-ipdc-products-for-not-edited-processes.sparql
+++ b/config/migrations/2026/versioning/20260330142101-fix-ipdc-products-for-not-edited-processes.sparql
@@ -1,0 +1,31 @@
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
+PREFIX dct:  <http://purl.org/dc/terms/>
+PREFIX dpv:  <https://w3id.org/dpv#>
+PREFIX ext:  <http://mu.semte.ch/vocabularies/ext/>
+PREFIX oph:  <http://lblod.data.gift/vocabularies/openproceshuis/>
+PREFIX cpsv: <http://purl.org/vocab/cpsv#>
+
+INSERT {
+  GRAPH ?g {
+    ?ipdcProduct cpsv:follows ?versionedProcess .
+  }
+}
+WHERE {
+  ?versionedProcess a ext:VersionedProcess .
+  ?versionedProcess dct:isVersionOf ?process .
+
+  FILTER NOT EXISTS {
+    ?otherVersion a ext:VersionedProcess .
+    ?otherVersion dct:isVersionOf ?process .
+    FILTER(?otherVersion != ?versionedProcess)
+  }
+
+  GRAPH ?g {
+    ?ipdcProduct cpsv:follows ?process .
+  }
+
+  FILTER NOT EXISTS {
+    ?ipdcProduct cpsv:follows ?versionedProcess .
+  }
+}


### PR DESCRIPTION
## 🗒️ Description

Process that did not have any versioned process resources yet and have an ipdc product show this as changed. The migration did not add these to the initial versioned processes. 

## 🦮 How to test

1. Run the migrations
2. Go to pittem "diagram" process
3. Edit the title
4. The ipdc product should not have changed

## 🔗 Links to other PR's

- https://github.com/lblod/frontend-openproceshuis/pull/246
