### PR TITLE
Allow SPARQL endpoint proxy to read public and inventory data

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -132,11 +132,6 @@
        :to-graph shared
        :for-allowed-group "shared-processes-reader")
 
-(with-scope "http://services.semantic.works/sparql-endpoint-proxy"
-  (grant (read)
-         :to shared
-         :for "authenticated"))
-
 (grant (read)
        :to-graph job
        :for-allowed-group "public")
@@ -176,6 +171,17 @@
 (grant (read)
        :to-graph error
        :for-allowed-group "admin")
+
+(with-scope "http://services.semantic.works/sparql-endpoint-proxy"
+  (grant (read)
+         :to shared
+         :for "authenticated")
+  (grant (read)
+         :to public
+         :for "public")
+  (grant (read)
+         :to inventory
+         :for "public"))
 
 ;;;;;;;;;
 ;;; Graphs


### PR DESCRIPTION
## 🗒️ Description

Before, the SPARQL endpoint proxy service already supported querying process data from the shared graph. However, more complex queries involving bestuurseenheid and inventory process data didn't give results as these triples are stored in other graphs.

Since those two graphs were already publicly availble, it only makes sense to also make them and their data available to the SPARQL endpoint proxy service. This PR makes that happen.

## 🦮 How to test

Start the application and go the the `/sparql` endpoint. Run the following query to check which types are available:

```sparql
SELECT DISTINCT ?type WHERE {
  ?s a ?type
}
```

The results should include `besluit:Bestuurseenheid` and `oph:ConceptueelProces`.

You can also test out the query from which this ticket originated:

```sparql
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
PREFIX dpv: <https://w3id.org/dpv#>
PREFIX dct: <http://purl.org/dc/terms/>
PREFIX icr: <http://lblod.data.gift/vocabularies/informationclassification/>
PREFIX adms: <http://www.w3.org/ns/adms#>

SELECT ?process ?title ?description ?organizationLabel ?isBlueprint
WHERE {
  graph <http://mu.semte.ch/graphs/public> {
    ?group a besluit:Bestuurseenheid ;
           skos:prefLabel ?organizationLabel .
  }

  graph <http://mu.semte.ch/graphs/shared> {
    ?process a dpv:Process .
    ?process dct:publisher ?group .
    ?process dct:title ?title .
    OPTIONAL { ?process dct:description ?description }
    OPTIONAL { ?process icr:isBlueprint ?isBlueprint }
    OPTIONAL { ?process adms:status ?status }
    FILTER(?status != <http://lblod.data.gift/concepts/concept-status/gearchiveerd> || !BOUND(?status))
  }
}
ORDER BY LCASE(?organizationLabel) LCASE(?title)
```

Before, this would give no results, but now it should.

## 🔗 Links to other PR's

- /
