### PR TITLE
OPH-906 | Visio isn't called correctly

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -46,7 +46,7 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://bpmn/"
   end
 
-  get "/visio/*path",  %{ accept: [:any], layer: :api } do
+  match "/visio/*path",  %{ accept: [:any], layer: :api } do
     Proxy.forward conn, path, "http://visio/"
   end
 


### PR DESCRIPTION
## 🗒️ Description

We noticed in the frontend that the visio extract bpmn elements is not called correctly. 

## 🦮 How to test

1. When uploading visio (vsdx) files in the frontend visio is reached to extract bbo elemnt extraction
2. As wel as a visio file is download as a bpmn extension the convert is called correctly

## 🔗 Links to other PR's

- /
